### PR TITLE
Set permissions explicitly

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,10 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   yamllint:
     runs-on: ubuntu-22.04
@@ -57,5 +61,9 @@ jobs:
   lint:
     name: Run super-linter job
     uses: bewuethr/workflows/.github/workflows/linter.yml@main
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
     with:
       validate-dockerfile: true

--- a/.github/workflows/releasetracker.yml
+++ b/.github/workflows/releasetracker.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
+permissions:
+  contents: write
+
 jobs:
   update-release-tags:
     name: Update release tags


### PR DESCRIPTION
To be able to limit default workflow permissions to read-only, this adds explicit workflow permissions.