### PR TITLE
Specify directory for mdl to run on

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,28 @@ individual rules.
 [2]: https://github.com/markdownlint/markdownlint/blob/master/docs/creating_styles.md
 [3]: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
 
+### `directory`
+
+**Optional** The path to run `mdl` against when linting markdown files.
+Defaults to current directory `.` if a directory is not specified.
+
 ## Example usage
+
+### with style-file
 
 ```yml
 uses: bewuethr/mdl-action@v1
 with:
   style-file: .github/workflows/style.rb
+```
+
+### with style-file and directory
+
+```yml
+uses: bewuethr/mdl-action@v1
+with:
+  style-file: .github/workflows/style.rb
+  directory: tests
 ```
 
 An example style file might look like this:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Defaults to current directory `.` if a directory is not specified.
 
 ## Example usage
 
-### with style-file
+### With style-file
 
 ```yml
 uses: bewuethr/mdl-action@v1
@@ -34,7 +34,7 @@ with:
   style-file: .github/workflows/style.rb
 ```
 
-### with style-file and directory
+### With style-file and directory
 
 ```yml
 uses: bewuethr/mdl-action@v1

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,8 @@ runs:
   using: docker
   image: Dockerfile
   args:
-    - ${{ inputs.directory }}
     - ${{ inputs.style-file }}
+    - ${{ inputs.directory }}
 branding:
   icon: check-circle
   color: green

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   directory:
     description: Directory to run mdl against
     required: false
-    default: '.'
+    default: .
 runs:
   using: docker
   image: Dockerfile

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,15 @@ inputs:
   style-file:
     description: Style file for mdl to use
     required: false
+  directory:
+    description: Directory to run mdl against
+    required: false
+    default: '.'
 runs:
   using: docker
   image: Dockerfile
   args:
+    - ${{ inputs.directory }}
     - ${{ inputs.style-file }}
 branding:
   icon: check-circle

--- a/runmdl
+++ b/runmdl
@@ -1,9 +1,10 @@
 #!/bin/sh
 
-stylefile=$1
+stylefile=$2
+directory=$1
 
 if [ -n "$stylefile" ]; then
-	mdl --style "$GITHUB_WORKSPACE/$stylefile" .
+	mdl --style "$GITHUB_WORKSPACE/$stylefile" "$directory"
 else
-	mdl .
+	mdl "$directory"
 fi

--- a/runmdl
+++ b/runmdl
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-stylefile=$2
-directory=$1
+stylefile=$1
+directory=$2
 
 if [ -n "$stylefile" ]; then
 	mdl --style "$GITHUB_WORKSPACE/$stylefile" "$directory"


### PR DESCRIPTION
resolves #34 

Allow a directory to be specified to mdl via mdl-action.

```yml
uses: bewuethr/mdl-action@v1
with:
  style-file: .github/workflows/style.rb
  directory: tests
```

Huge thanks to @bewuethr for being a sounding board and brainstorming.