### PR TITLE
Bump Ruby, Alpine, and mdl

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
         run: curl "$STYLE_FILE" > .github/workflows/style.rb
 
       - name: Run Markdown linter
-        uses: bewuethr/mdl-action@v1
+        uses: ./.
         with:
           style-file: .github/workflows/style.rb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.2-alpine3.17
-RUN gem install mdl -v 0.12.0
+FROM ruby:3.3.5-alpine3.20
+RUN gem install mdl -v 0.13.0
 COPY runmdl /runmdl
 ENTRYPOINT ["/runmdl"]

--- a/README.md
+++ b/README.md
@@ -3,21 +3,21 @@
 ![Linting](https://github.com/bewuethr/mdl-action/workflows/Linting/badge.svg)
 ![Move release tags](https://github.com/bewuethr/mdl-action/workflows/Move%20release%20tags/badge.svg)
 
-This action runs the Ruby Markdown linter [mdl][1] on every Markdown file in
-the repository.
+This action runs the Ruby Markdown linter [mdl] on every Markdown file in the
+repository.
 
-[1]: https://github.com/markdownlint/markdownlint
+[mdl]: https://github.com/markdownlint/markdownlint
 
 ## Inputs
 
 ### `style-file`
 
 **Optional** The path to the style file for `mdl` to use. See [Creating
-styles][2] to learn about markdownlint style files, and [`RULES.md`][3] for the
+styles][cs] to learn about markdownlint style files, and [`RULES.md`] for the
 individual rules.
 
-[2]: https://github.com/markdownlint/markdownlint/blob/master/docs/creating_styles.md
-[3]: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+[cs]: <https://github.com/markdownlint/markdownlint/blob/master/docs/creating_styles.md>
+[`RULES.md`]: <https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md>
 
 ### `directory`
 
@@ -43,25 +43,27 @@ with:
   directory: tests
 ```
 
+## Style file
+
 An example style file might look like this:
 
 ```rb
 all
 
 # Don't enforce line length in code blocks
-rule 'MD013', :code_blocks => false
+rule "MD013", code_blocks: false
 
 # Allow duplicate titles
-exclude_rule 'MD024'
+exclude_rule "MD024"
 
 # Allow titles to end in question marks
-rule 'MD026', :punctuation => '.,;:!'
+rule "MD026", punctuation: ".,;:!"
 
-# Don't force ordered lists with 1. 1. 1.
-rule 'MD029', :style => :ordered
+# Don"t force ordered lists with 1. 1. 1.
+rule "MD029", style: :ordered
 
 # Allow inline HTML
-exclude_rule 'MD033'
+exclude_rule "MD033"
 ```
 
 ## Versions
@@ -94,6 +96,6 @@ will fetch `v1.1.2`. The advantage of using just `@v1` is that minor releases
 and patches are included without requiring a change; the advantage of using
 `@v1.1.2` is knowing that the action does 100% the same thing every time.
 
-This is done via the [release-tag-tracker][4] action.
+This is done via the [release-tag-tracker][rtt] action.
 
-[4]: https://github.com/marketplace/actions/release-tag-tracker
+[rtt]: <https://github.com/marketplace/actions/release-tag-tracker>


### PR DESCRIPTION
Bump Alpine, Ruby, and mdl versions; update README to use standard Ruby syntax in the style file example.

Switch markdownlint job to use action at HEAD instead of v1.